### PR TITLE
feat: add tracking image to post footer

### DIFF
--- a/kristoffer.is/packages/writing/src/layouts/post.tsx
+++ b/kristoffer.is/packages/writing/src/layouts/post.tsx
@@ -82,6 +82,10 @@ export default function PostLayout({
         `}
       >
         &copy; 2020 Kristoffer Sachse
+        <img
+          alt=""
+          src="https://kristoffer.goatcounter.com/count?p=/test-img"
+        />
       </footer>
     </>
   );


### PR DESCRIPTION
To get a general idea of amount of post views. Respects user privacy.