### PR TITLE
🔨 enable swc by removing babel config

### DIFF
--- a/packages/writing/.babelrc.js
+++ b/packages/writing/.babelrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  presets: ["next/babel", "@emotion/babel-preset-css-prop"],
-};

--- a/packages/writing/.eslintrc.js
+++ b/packages/writing/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   plugins: ["@emotion/eslint-plugin"],
   root: true,
   rules: {
+    "@emotion/jsx-import": "off",
     "@emotion/syntax-preference": ["error", "string"],
     "react/react-in-jsx-scope": "off",
   },

--- a/packages/writing/next.config.mjs
+++ b/packages/writing/next.config.mjs
@@ -36,6 +36,10 @@ export default withMDX({
   assetPrefix: isProduction ? "/writing" : "",
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
 
+  compiler: {
+    emotion: true,
+  },
+
   experimental: {
     esmExternals: true,
   },

--- a/packages/writing/tsconfig.json
+++ b/packages/writing/tsconfig.json
@@ -13,6 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "jsxImportSource": "@emotion/react",
     "incremental": true
   },
   "exclude": ["node_modules"],


### PR DESCRIPTION
We can use `"jsxImportSource": "@emotion/react",` in tsconfig.json instead